### PR TITLE
Fix case mismatch in default acceptenv values

### DIFF
--- a/tsshd/sshd_config.go
+++ b/tsshd/sshd_config.go
@@ -130,7 +130,7 @@ func parseSshdConfig(path, user string, groups []string) {
 	// We follow this convention as our internal default. However, we also
 	// support explicitly setting AcceptEnv to an empty value in the
 	// configuration to override this behavior and clear all accepted variables.
-	sshdConfigMap["AcceptEnv"] = "LANG LC_*"
+	sshdConfigMap["acceptenv"] = "LANG LC_*"
 
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
The default was stored with a mixed case key while everything else was using lowercase.