### PR TITLE
feat: honor StreamLocalBindMask and StreamLocalBindUnlink with safe cleanup

### DIFF
--- a/tsshd/forward.go
+++ b/tsshd/forward.go
@@ -28,9 +28,49 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 )
+
+// streamLocalBindMask returns the StreamLocalBindMask from sshd_config.
+// OpenSSH's default is 0177.
+func streamLocalBindMask() int {
+	v := getSshdConfig("StreamLocalBindMask")
+	if v == "" {
+		return 0177
+	}
+	mask, err := strconv.ParseInt(v, 8, 32)
+	if err != nil || mask < 0 || mask > 0777 {
+		warning("invalid StreamLocalBindMask [%s] in [%s], using default 0177", v, sshdConfigPath)
+		return 0177
+	}
+	return int(mask)
+}
+
+// unlinkStaleUnixSocket honors StreamLocalBindUnlink from sshd_config. If the
+// path exists and is a unix socket, it is removed. Non-socket files are
+// refused. Missing paths are a no-op.
+func unlinkStaleUnixSocket(path string) error {
+	if strings.ToLower(getSshdConfig("StreamLocalBindUnlink")) != "yes" {
+		return nil
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to unlink non-socket path: %s", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	debug("unlinked existing unix socket [%s] per StreamLocalBindUnlink", path)
+	return nil
+}
 
 func sendProhibited(stream Stream, option string) {
 	sendErrorCode(stream, ErrProhibited, fmt.Sprintf("Check [%s] in [%s] on the server.", option, sshdConfigPath))
@@ -115,10 +155,24 @@ func (s *sshUdpServer) handleListenEvent(stream Stream) {
 		return
 	}
 
+	if msg.Net == "unix" {
+		if err := unlinkStaleUnixSocket(msg.Addr); err != nil {
+			sendError(stream, err)
+			return
+		}
+	}
+
 	listener, err := net.Listen(msg.Net, msg.Addr)
 	if err != nil {
 		sendError(stream, err)
 		return
+	}
+
+	if msg.Net == "unix" {
+		mode := os.FileMode(0666) &^ os.FileMode(streamLocalBindMask())
+		if err := os.Chmod(msg.Addr, mode); err != nil {
+			warning("chmod unix socket [%s] to %#o failed: %v", msg.Addr, mode, err)
+		}
 	}
 
 	addOnExitFunc(func() {

--- a/tsshd/forward.go
+++ b/tsshd/forward.go
@@ -168,18 +168,31 @@ func (s *sshUdpServer) handleListenEvent(stream Stream) {
 		return
 	}
 
+	var createdInfo os.FileInfo
 	if msg.Net == "unix" {
 		mode := os.FileMode(0666) &^ os.FileMode(streamLocalBindMask())
 		if err := os.Chmod(msg.Addr, mode); err != nil {
 			warning("chmod unix socket [%s] to %#o failed: %v", msg.Addr, mode, err)
 		}
+		if info, err := os.Stat(msg.Addr); err == nil {
+			createdInfo = info
+		}
 	}
 
 	addOnExitFunc(func() {
 		_ = listener.Close()
-		if msg.Net == "unix" {
-			_ = os.Remove(msg.Addr)
+		if msg.Net != "unix" || createdInfo == nil {
+			return
 		}
+		current, err := os.Stat(msg.Addr)
+		if err != nil {
+			return
+		}
+		if !os.SameFile(createdInfo, current) {
+			debug("unix socket [%s] replaced since creation; skipping unlink", msg.Addr)
+			return
+		}
+		_ = os.Remove(msg.Addr)
 	})
 	defer func() { _ = listener.Close() }()
 


### PR DESCRIPTION
Adds OpenSSH-aligned handling of `StreamLocalBindMask` and `StreamLocalBindUnlink` for forwarded unix sockets, driven entirely by `sshd_config` — no signaling from the client.

### Behavior

Before `Listen` on a unix socket:
- If `StreamLocalBindUnlink=yes`, lstat the path; unlink only if it is a unix socket. Non-socket paths and unlink failures return an error. Successful removals are debug-logged.

After `Listen`:
- Chmod the socket to `0666 &^ StreamLocalBindMask` (default `0177` per OpenSSH). Chmod failure is a warning, not fatal.

### Safe cleanup

On exit, the daemon used to unconditionally unlink any socket it had created. This PR records the `(dev, inode)` of the socket at creation time (via `os.Stat`) and only unlinks at cleanup if `os.SameFile` confirms the path still refers to the same file. If another process has replaced the socket in the interim, the cleanup is skipped.

### Context

Companion to client-side PR at trzsz/trzsz-ssh#229. Server-side and client-side are independent — each side enforces its own policy from its own configuration.