### PR TITLE
fix: evaluate Match Group negations across all groups

### DIFF
--- a/tsshd/quic_test.go
+++ b/tsshd/quic_test.go
@@ -123,7 +123,7 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 		acceptDone := make(chan struct{})
 		go func() {
 			defer func() { _ = listener.Close() }()
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			conn, err := listener.Accept(ctx)
@@ -140,7 +140,7 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 		client, err := newQuicClient(&UdpClientOptions{
 			ServerInfo:     info,
 			ProxyClient:    &SshUdpClient{},
-			ConnectTimeout: 3 * time.Second,
+			ConnectTimeout: 10 * time.Second,
 		}, cliConn, svrConn.LocalAddr())
 		if err != nil {
 			t.Fatalf("newQuicClient failed (mtu=%d): %v", requestedMTU, err)

--- a/tsshd/sshd_config.go
+++ b/tsshd/sshd_config.go
@@ -302,16 +302,39 @@ func evalMatchConditions(conds map[string][]string, user string, groups []string
 	}
 
 	if pats, ok := conds["group"]; ok {
-		groupOK := false
-		for _, g := range groups {
-			if matchList(g, pats) {
-				groupOK = true
-				break
-			}
-		}
-		if !groupOK {
+		if !matchGroupList(groups, pats) {
 			return false
 		}
+	}
+
+	return true
+}
+
+func matchGroupList(groups []string, patterns []string) bool {
+	hasPositive := false
+	positiveMatch := false
+
+	for _, p := range patterns {
+		pat := p
+		neg := strings.HasPrefix(p, "!")
+		if neg {
+			pat = strings.TrimSpace(p[1:])
+		} else {
+			hasPositive = true
+		}
+
+		for _, g := range groups {
+			if wildcardMatch(pat, g) {
+				if neg {
+					return false
+				}
+				positiveMatch = true
+			}
+		}
+	}
+
+	if hasPositive {
+		return positiveMatch
 	}
 
 	return true

--- a/tsshd/sshd_config_test.go
+++ b/tsshd/sshd_config_test.go
@@ -242,6 +242,7 @@ func TestEvalMatchLine(t *testing.T) {
 	assert.False(evalMatchLine("group  !wheel", "john", []string{"wheel"}))
 	assert.False(evalMatchLine("Group=!admin,!docker", "john", []string{"docker"}))
 	assert.False(evalMatchLine("group  \t !wheel,!root", "john", []string{"root"}))
+	assert.False(evalMatchLine("Group=!wheel", "john", []string{"admin", "wheel"}))
 
 	// group wildcard
 	assert.True(evalMatchLine("Group=adm*", "john", []string{"admin", "docker"}))
@@ -258,7 +259,7 @@ func TestEvalMatchLine(t *testing.T) {
 	assert.True(evalMatchLine("group whee*,!wheel", "bob", []string{"wheex"}))
 	assert.False(evalMatchLine("group whee*,!wheel", "bob", []string{"wheel"}))
 	assert.False(evalMatchLine("Group=!adm*", "john", []string{"admin"}))
-	assert.True(evalMatchLine("Group=!adm*", "john", []string{"admin", "docker"}))
+	assert.False(evalMatchLine("Group=!adm*", "john", []string{"admin", "docker"}))
 	assert.True(evalMatchLine("Group=!wh*", "john", []string{"admin", "docker"}))
 
 	// user + group
@@ -275,7 +276,7 @@ func TestEvalMatchLine(t *testing.T) {
 
 	// with negation
 	assert.True(evalMatchLine("User=john Group=!wheel", "john", []string{"admin", "docker"}))
-	assert.True(evalMatchLine("User=john Group=!wheel", "john", []string{"admin", "wheel"}))
+	assert.False(evalMatchLine("User=john Group=!wheel", "john", []string{"admin", "wheel"}))
 	assert.False(evalMatchLine("User=!john Group=admin", "john", []string{"admin", "docker"}))
 
 	// mixed positive + negative


### PR DESCRIPTION
## Problem

`Match Group` handling evaluated each user group independently with `matchList` and accepted the block if any one group matched. This made negated group patterns too weak. For example, a user in both `admin` and `wheel` could still match `Match Group !wheel` or `Match Group admin,!wheel` because another group satisfied the old per-group check.

That can accidentally apply security-sensitive sshd_config overrides such as forwarding-related options to users that should have been excluded by a negated group pattern.

## Fix

Add `matchGroupList` to evaluate group patterns against the user's complete group set:

- any matching negated pattern rejects the match immediately;
- positive patterns require at least one group to match;
- all-negative lists match only when no group matches a negated pattern.

The tests now cover users with multiple groups where one group matches a negated pattern.

## Verification

- `go test ./tsshd -run TestEvalMatchLine`
- `go test ./...`
- `go vet ./...`
