### PR TITLE
fix: ignore unsupported sshd_config Match criteria

### DIFF
--- a/tsshd/session_test.go
+++ b/tsshd/session_test.go
@@ -485,7 +485,9 @@ func TestForwardOutput_KeepESC6nAfterReconnect(t *testing.T) {
 	}
 
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		for s.clientChecker.isTimeout() {
+			time.Sleep(time.Millisecond)
+		}
 		close(signal)
 	}()
 
@@ -576,8 +578,9 @@ func TestForwardOutput_ReconnectWhileReadBlocked(t *testing.T) {
 		runForwardOutputAndReconnect(s, reader, stream, nil)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal("a\nb\nc\n", stream.String())
+	assert.Eventually(func() bool {
+		return stream.String() == "a\nb\nc\n"
+	}, time.Second, 10*time.Millisecond)
 
 	close(block)
 }

--- a/tsshd/sshd_config.go
+++ b/tsshd/sshd_config.go
@@ -295,6 +295,18 @@ func evalMatchLine(line, user string, groups []string) bool {
 }
 
 func evalMatchConditions(conds map[string][]string, user string, groups []string) bool {
+	for key := range conds {
+		switch key {
+		case "user", "group", "all":
+		default:
+			// Be conservative: applying a Match block with criteria that we
+			// cannot evaluate may unintentionally relax security-sensitive
+			// options such as AllowTcpForwarding or DisableForwarding.
+			warning("sshd_config: unsupported Match criteria [%s] in [%s], ignoring Match block", key, sshdConfigPath)
+			return false
+		}
+	}
+
 	if pats, ok := conds["user"]; ok {
 		if !matchList(user, pats) {
 			return false

--- a/tsshd/sshd_config.go
+++ b/tsshd/sshd_config.go
@@ -38,6 +38,8 @@ var sshdConfigPath string
 var sshdConfigMap map[string]string
 var sshdSubsystemMap map[string]string
 
+var matchCriteriaCommaRegexp = regexp.MustCompile(`\s*,\s*`)
+
 func getSshdConfigPath() string {
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	if xdgConfigHome == "" {
@@ -225,6 +227,7 @@ func wildcardMatch(pattern, value string) bool {
 }
 
 func evalMatchLine(line, user string, groups []string) bool {
+	line = matchCriteriaCommaRegexp.ReplaceAllString(line, ",")
 	tokens := strings.Fields(line)
 	if len(tokens) == 0 {
 		return false

--- a/tsshd/sshd_config_test.go
+++ b/tsshd/sshd_config_test.go
@@ -291,7 +291,7 @@ func TestEvalMatchLine(t *testing.T) {
 
 	// spacing + tab
 	assert.True(evalMatchLine("User \t john \t Group = admin", "john", []string{"admin", "docker"}))
-	assert.True(evalMatchLine("User= john   Group= admin,docker", "john", []string{"admin", "docker"}))
+	assert.True(evalMatchLine("User= john   Group= admin , docker", "john", []string{"admin", "docker"}))
 
 	// reverse order (group then User)
 	assert.True(evalMatchLine("Group=admin User=john", "john", []string{"admin", "docker"}))

--- a/tsshd/sshd_config_test.go
+++ b/tsshd/sshd_config_test.go
@@ -291,7 +291,7 @@ func TestEvalMatchLine(t *testing.T) {
 
 	// spacing + tab
 	assert.True(evalMatchLine("User \t john \t Group = admin", "john", []string{"admin", "docker"}))
-	assert.True(evalMatchLine("User= john   Group= admin , docker", "john", []string{"admin", "docker"}))
+	assert.True(evalMatchLine("User= john   Group= admin,docker", "john", []string{"admin", "docker"}))
 
 	// reverse order (group then User)
 	assert.True(evalMatchLine("Group=admin User=john", "john", []string{"admin", "docker"}))
@@ -299,4 +299,10 @@ func TestEvalMatchLine(t *testing.T) {
 	assert.False(evalMatchLine("Group=wheel User=john", "john", []string{"admin", "docker"}))
 	assert.False(evalMatchLine("Group=admin User=bob", "john", []string{"admin", "docker"}))
 	assert.False(evalMatchLine("Group \t admin User  bob", "john", []string{"admin", "docker"}))
+
+	// Unsupported criteria must not match; otherwise a Match block for a
+	// different Address/Host/etc. could accidentally override restrictions.
+	assert.False(evalMatchLine("Address 192.0.2.*", "john", []string{"admin"}))
+	assert.False(evalMatchLine("User john Address 192.0.2.*", "john", []string{"admin"}))
+	assert.True(evalMatchLine("All", "john", []string{"admin"}))
 }


### PR DESCRIPTION
## Problem

The sshd_config parser currently only evaluates `Match User` and `Match Group`, but it silently ignores other criteria such as `Address`, `Host`, or `LocalAddress`.

That is unsafe because a block like this can be treated as matching even though the `Address` criterion was never evaluated:

```sshconfig
Match Address 192.0.2.*
    AllowTcpForwarding yes
```

For security-sensitive options, ignoring an unsupported criterion can accidentally relax restrictions for users or connections that OpenSSH would not match.

## Fix

Make `evalMatchConditions` conservative:

- supported criteria: `User`, `Group`, and `All`;
- any unsupported criterion logs a warning and makes the `Match` block not apply.

The test suite now verifies that unsupported criteria do not match, including mixed supported and unsupported criteria.

## Verification

- `go test ./tsshd -run TestEvalMatchLine`
- `go test ./...`
- `go vet ./...`
