### PR TITLE
fix: avoid shared QUIC config mutation

### DIFF
--- a/tsshd/proto.go
+++ b/tsshd/proto.go
@@ -511,17 +511,15 @@ func newQuicClient(opts *UdpClientOptions, udpConn net.PacketConn, remoteAddr ne
 	}
 
 	config := quicConfig
-	var initialPacketSize uint16
 	if opts.ServerInfo.MTU != 0 {
-		initialPacketSize = quicInitialPacketSize(opts.ServerInfo.MTU)
+		config.InitialPacketSize = opts.ServerInfo.MTU
 		config.DisablePathMTUDiscovery = true
 	} else if opts.ProxyClient != nil {
-		initialPacketSize = quicInitialPacketSize(opts.ProxyClient.GetMaxDatagramSize())
+		config.InitialPacketSize = opts.ProxyClient.GetMaxDatagramSize()
 		config.DisablePathMTUDiscovery = true
 	} else {
-		initialPacketSize = kDefaultMTU
+		config.InitialPacketSize = kDefaultMTU
 	}
-	config.InitialPacketSize = initialPacketSize
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.ConnectTimeout)
 	defer cancel()
@@ -529,5 +527,5 @@ func newQuicClient(opts *UdpClientOptions, udpConn net.PacketConn, remoteAddr ne
 	if err != nil {
 		return nil, fmt.Errorf("quic dail [%v] failed: %w", remoteAddr.String(), err)
 	}
-	return &quicClient{conn, &udpForwarder{conn: newQuicDatagramConn(conn, initialPacketSize)}}, nil
+	return &quicClient{conn, &udpForwarder{conn: newQuicDatagramConn(conn, config.InitialPacketSize)}}, nil
 }

--- a/tsshd/proto.go
+++ b/tsshd/proto.go
@@ -510,21 +510,24 @@ func newQuicClient(opts *UdpClientOptions, udpConn net.PacketConn, remoteAddr ne
 		ServerName:   "tsshd",
 	}
 
+	config := quicConfig
+	var initialPacketSize uint16
 	if opts.ServerInfo.MTU != 0 {
-		quicConfig.InitialPacketSize = opts.ServerInfo.MTU
-		quicConfig.DisablePathMTUDiscovery = true
+		initialPacketSize = quicInitialPacketSize(opts.ServerInfo.MTU)
+		config.DisablePathMTUDiscovery = true
 	} else if opts.ProxyClient != nil {
-		quicConfig.InitialPacketSize = opts.ProxyClient.GetMaxDatagramSize()
-		quicConfig.DisablePathMTUDiscovery = true
+		initialPacketSize = quicInitialPacketSize(opts.ProxyClient.GetMaxDatagramSize())
+		config.DisablePathMTUDiscovery = true
 	} else {
-		quicConfig.InitialPacketSize = kDefaultMTU
+		initialPacketSize = kDefaultMTU
 	}
+	config.InitialPacketSize = initialPacketSize
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.ConnectTimeout)
 	defer cancel()
-	conn, err := quic.Dial(ctx, udpConn, remoteAddr, tlsConfig, &quicConfig)
+	conn, err := quic.Dial(ctx, udpConn, remoteAddr, tlsConfig, &config)
 	if err != nil {
 		return nil, fmt.Errorf("quic dail [%v] failed: %w", remoteAddr.String(), err)
 	}
-	return &quicClient{conn, &udpForwarder{conn: newQuicDatagramConn(conn)}}, nil
+	return &quicClient{conn, &udpForwarder{conn: newQuicDatagramConn(conn, initialPacketSize)}}, nil
 }

--- a/tsshd/quic_test.go
+++ b/tsshd/quic_test.go
@@ -95,14 +95,15 @@ func listenRandomUDP(t *testing.T) *udpPacketConn {
 	return &udpPacketConn{conn}
 }
 
-// TestQUIC_InitialPacketSize verifies that listenQUIC clamps
-// quicConfig.InitialPacketSize to the valid MTU range.
-//
-// NOTE: newQuicDatagramConn relies on quicConfig.InitialPacketSize being
-// adjusted by quic during listener initialization. If quic does not perform
-// this adjustment, newQuicDatagramConn must be updated accordingly.
+// TestQUIC_InitialPacketSize verifies that QUIC packet size selection clamps
+// the requested MTU to the valid MTU range without mutating the shared base
+// quicConfig.
 func TestQUIC_InitialPacketSize(t *testing.T) {
 	verifyInitialPacketSize := func(requestedMTU, expectedMTU uint16) {
+		if got := quicInitialPacketSize(requestedMTU); got != expectedMTU {
+			t.Fatalf("quicInitialPacketSize mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
+		}
+
 		info := &ServerInfo{MTU: requestedMTU}
 		svrConn := listenRandomUDP(t)
 		defer func() { _ = svrConn.Close() }()
@@ -116,14 +117,14 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 			t.Fatalf("listenQUIC failed (mtu=%d): %v", requestedMTU, err)
 		}
 
-		if got := quicConfig.InitialPacketSize; got != expectedMTU {
-			t.Fatalf("InitialPacketSize mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
+		if got := quicConfig.InitialPacketSize; got != 0 {
+			t.Fatalf("shared quicConfig should not be mutated by listenQUIC, got InitialPacketSize=%d", got)
 		}
 
 		acceptDone := make(chan struct{})
 		go func() {
 			defer func() { _ = listener.Close() }()
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			conn, err := listener.Accept(ctx)
@@ -140,17 +141,20 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 		client, err := newQuicClient(&UdpClientOptions{
 			ServerInfo:     info,
 			ProxyClient:    &SshUdpClient{},
-			ConnectTimeout: 3 * time.Second,
+			ConnectTimeout: 10 * time.Second,
 		}, cliConn, svrConn.LocalAddr())
 		if err != nil {
 			t.Fatalf("newQuicClient failed (mtu=%d): %v", requestedMTU, err)
+		}
+		if got := client.forwarder.conn.GetMaxDatagramSize() + kQuicShortHeaderSize + kUdpForwardChannelIdSize; got != expectedMTU {
+			t.Fatalf("client initial packet size mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
 		}
 		_ = client.closeClient()
 
 		<-acceptDone
 
-		if got := quicConfig.InitialPacketSize; got != expectedMTU {
-			t.Fatalf("InitialPacketSize mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
+		if got := quicConfig.InitialPacketSize; got != 0 {
+			t.Fatalf("shared quicConfig should not be mutated, got InitialPacketSize=%d", got)
 		}
 	}
 

--- a/tsshd/quic_test.go
+++ b/tsshd/quic_test.go
@@ -100,10 +100,6 @@ func listenRandomUDP(t *testing.T) *udpPacketConn {
 // quicConfig.
 func TestQUIC_InitialPacketSize(t *testing.T) {
 	verifyInitialPacketSize := func(requestedMTU, expectedMTU uint16) {
-		if got := quicInitialPacketSize(requestedMTU); got != expectedMTU {
-			t.Fatalf("quicInitialPacketSize mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
-		}
-
 		info := &ServerInfo{MTU: requestedMTU}
 		svrConn := listenRandomUDP(t)
 		defer func() { _ = svrConn.Close() }()
@@ -112,11 +108,14 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 
 		// Server
 		quicConfig.InitialPacketSize = 0
-		listener, err := listenQUIC(svrConn, info, requestedMTU)
+		listener, serverInitialPacketSize, err := listenQUIC(svrConn, info, requestedMTU)
 		if err != nil {
 			t.Fatalf("listenQUIC failed (mtu=%d): %v", requestedMTU, err)
 		}
 
+		if serverInitialPacketSize != expectedMTU {
+			t.Fatalf("server initial packet size mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, serverInitialPacketSize)
+		}
 		if got := quicConfig.InitialPacketSize; got != 0 {
 			t.Fatalf("shared quicConfig should not be mutated by listenQUIC, got InitialPacketSize=%d", got)
 		}
@@ -149,34 +148,22 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 		if got := client.forwarder.conn.GetMaxDatagramSize() + kQuicShortHeaderSize + kUdpForwardChannelIdSize; got != expectedMTU {
 			t.Fatalf("client initial packet size mismatch: requested=%d, expected=%d, got=%d", requestedMTU, expectedMTU, got)
 		}
-		_ = client.closeClient()
-
 		<-acceptDone
+		_ = client.closeClient()
 
 		if got := quicConfig.InitialPacketSize; got != 0 {
 			t.Fatalf("shared quicConfig should not be mutated, got InitialPacketSize=%d", got)
 		}
 	}
 
-	const (
-		expectedQuicMinMTU uint16 = 1200
-		expectedQuicMaxMTU uint16 = 1452
-	)
-	if kQuicMinMTU != expectedQuicMinMTU {
-		t.Fatalf("kQuicMinMTU changed: expected=%d, got=%d", expectedQuicMinMTU, kQuicMinMTU)
-	}
-	if kQuicMaxMTU != expectedQuicMaxMTU {
-		t.Fatalf("kQuicMaxMTU changed: expected=%d, got=%d", expectedQuicMaxMTU, kQuicMaxMTU)
-	}
-
 	// MTU below min
-	verifyInitialPacketSize(expectedQuicMinMTU-1, expectedQuicMinMTU)
+	verifyInitialPacketSize(kQuicMinMTU-1, kQuicMinMTU)
 
 	// Default MTU
 	verifyInitialPacketSize(kDefaultMTU, kDefaultMTU)
 
 	// MTU above max
-	verifyInitialPacketSize(expectedQuicMaxMTU+1, expectedQuicMaxMTU)
+	verifyInitialPacketSize(kQuicMaxMTU+1, kQuicMaxMTU)
 }
 
 // TestQUIC_ShortHeaderSize ensures that the constant kQuicShortHeaderSize
@@ -234,7 +221,7 @@ func TestQUIC_RespectMTU(t *testing.T) {
 	svrConn := &mtuTestConn{udpPacketConn: listenRandomUDP(t), t: t, mtu: mtu}
 	defer func() { _ = svrConn.Close() }()
 
-	listener, err := listenQUIC(svrConn, info, mtu)
+	listener, _, err := listenQUIC(svrConn, info, mtu)
 	if err != nil {
 		t.Fatalf("listenQUIC failed: %v", err)
 	}
@@ -433,7 +420,7 @@ func TestQUIC_CertValidation(t *testing.T) {
 	defer func() { _ = svrConn.Close() }()
 
 	// Start QUIC server
-	listener, err := listenQUIC(svrConn, &info, 0)
+	listener, _, err := listenQUIC(svrConn, &info, 0)
 	if err != nil {
 		t.Fatalf("listenQUIC failed: %v", err)
 	}

--- a/tsshd/quic_test.go
+++ b/tsshd/quic_test.go
@@ -158,14 +158,25 @@ func TestQUIC_InitialPacketSize(t *testing.T) {
 		}
 	}
 
+	const (
+		expectedQuicMinMTU uint16 = 1200
+		expectedQuicMaxMTU uint16 = 1452
+	)
+	if kQuicMinMTU != expectedQuicMinMTU {
+		t.Fatalf("kQuicMinMTU changed: expected=%d, got=%d", expectedQuicMinMTU, kQuicMinMTU)
+	}
+	if kQuicMaxMTU != expectedQuicMaxMTU {
+		t.Fatalf("kQuicMaxMTU changed: expected=%d, got=%d", expectedQuicMaxMTU, kQuicMaxMTU)
+	}
+
 	// MTU below min
-	verifyInitialPacketSize(kQuicMinMTU-1, kQuicMinMTU)
+	verifyInitialPacketSize(expectedQuicMinMTU-1, expectedQuicMinMTU)
 
 	// Default MTU
 	verifyInitialPacketSize(kDefaultMTU, kDefaultMTU)
 
 	// MTU above max
-	verifyInitialPacketSize(kQuicMaxMTU+1, kQuicMaxMTU)
+	verifyInitialPacketSize(expectedQuicMaxMTU+1, expectedQuicMaxMTU)
 }
 
 // TestQUIC_ShortHeaderSize ensures that the constant kQuicShortHeaderSize

--- a/tsshd/service.go
+++ b/tsshd/service.go
@@ -74,6 +74,19 @@ var quicConfig = quic.Config{
 	EnableDatagrams:      true,
 }
 
+func quicInitialPacketSize(mtu uint16) uint16 {
+	if mtu == 0 {
+		return kDefaultMTU
+	}
+	if mtu < kQuicMinMTU {
+		return kQuicMinMTU
+	}
+	if mtu > kQuicMaxMTU {
+		return kQuicMaxMTU
+	}
+	return mtu
+}
+
 var smuxConfig = smux.Config{
 	Version:           2,
 	KeepAliveDisabled: true,
@@ -149,7 +162,7 @@ func initServer(args *tsshdArgs) (string, error) {
 			return "", err
 		}
 		addOnExitFunc(func() { _ = listener.Close() })
-		go serveQUIC(args, proxy, listener)
+		go serveQUIC(args, proxy, listener, quicInitialPacketSize(args.MTU))
 	}
 
 	infoStr, err := json.Marshal(info)
@@ -443,14 +456,11 @@ func listenQUIC(conn net.PacketConn, info *ServerInfo, mtu uint16) (*quic.Listen
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 	}
 
-	if mtu > 0 {
-		quicConfig.InitialPacketSize = mtu
-		quicConfig.DisablePathMTUDiscovery = true
-	} else {
-		quicConfig.InitialPacketSize = kDefaultMTU
-	}
+	config := quicConfig
+	config.InitialPacketSize = quicInitialPacketSize(mtu)
+	config.DisablePathMTUDiscovery = mtu > 0
 
-	listener, err := (&quic.Transport{Conn: conn}).Listen(tlsConfig, &quicConfig)
+	listener, err := (&quic.Transport{Conn: conn}).Listen(tlsConfig, &config)
 	if err != nil {
 		return nil, fmt.Errorf("quic listen failed: %v", err)
 	}
@@ -583,12 +593,10 @@ type quicDatagramConn struct {
 	mtu uint16
 }
 
-func newQuicDatagramConn(conn *quic.Conn) datagramConn {
+func newQuicDatagramConn(conn *quic.Conn, initialPacketSize uint16) datagramConn {
 	return &quicDatagramConn{
 		conn,
-		// This depends on quicConfig.InitialPacketSize being properly clamped to the valid MTU range.
-		// See TestQUIC_InitialPacketSize for the test that ensures this behavior.
-		quicConfig.InitialPacketSize - kQuicShortHeaderSize - kUdpForwardChannelIdSize, // Reserve 8 bytes from the MTU for the channel ID
+		initialPacketSize - kQuicShortHeaderSize - kUdpForwardChannelIdSize, // Reserve 8 bytes from the MTU for the channel ID
 	}
 }
 
@@ -649,7 +657,7 @@ func handleKcpConn(args *tsshdArgs, proxy *serverProxy, conn *kcp.UDPSession) {
 	}
 }
 
-func serveQUIC(args *tsshdArgs, proxy *serverProxy, listener *quic.Listener) {
+func serveQUIC(args *tsshdArgs, proxy *serverProxy, listener *quic.Listener, initialPacketSize uint16) {
 	for {
 		conn, err := listener.Accept(context.Background())
 		if err != nil {
@@ -657,11 +665,11 @@ func serveQUIC(args *tsshdArgs, proxy *serverProxy, listener *quic.Listener) {
 			return
 		}
 		debug("quic accepted new connection from client [%v]", conn.RemoteAddr())
-		go handleQuicConn(args, proxy, conn)
+		go handleQuicConn(args, proxy, conn, initialPacketSize)
 	}
 }
 
-func handleQuicConn(args *tsshdArgs, proxy *serverProxy, conn *quic.Conn) {
+func handleQuicConn(args *tsshdArgs, proxy *serverProxy, conn *quic.Conn, initialPacketSize uint16) {
 	defer func() { _ = conn.CloseWithError(0, "") }()
 
 	if !args.Attachable {
@@ -670,7 +678,7 @@ func handleQuicConn(args *tsshdArgs, proxy *serverProxy, conn *quic.Conn) {
 		}
 	}
 
-	server := newSshUdpServer(args, proxy, conn.RemoteAddr(), &quicServer{conn, &udpForwarder{conn: newQuicDatagramConn(conn)}})
+	server := newSshUdpServer(args, proxy, conn.RemoteAddr(), &quicServer{conn, &udpForwarder{conn: newQuicDatagramConn(conn, initialPacketSize)}})
 	if server == nil {
 		return
 	}

--- a/tsshd/service.go
+++ b/tsshd/service.go
@@ -74,19 +74,6 @@ var quicConfig = quic.Config{
 	EnableDatagrams:      true,
 }
 
-func quicInitialPacketSize(mtu uint16) uint16 {
-	if mtu == 0 {
-		return kDefaultMTU
-	}
-	if mtu < kQuicMinMTU {
-		return kQuicMinMTU
-	}
-	if mtu > kQuicMaxMTU {
-		return kQuicMaxMTU
-	}
-	return mtu
-}
-
 var smuxConfig = smux.Config{
 	Version:           2,
 	KeepAliveDisabled: true,
@@ -157,12 +144,12 @@ func initServer(args *tsshdArgs) (string, error) {
 		addOnExitFunc(func() { _ = listener.Close() })
 		go serveKCP(args, proxy, listener)
 	} else {
-		listener, err := listenQUIC(proxy, info, args.MTU)
+		listener, initialPacketSize, err := listenQUIC(proxy, info, args.MTU)
 		if err != nil {
 			return "", err
 		}
 		addOnExitFunc(func() { _ = listener.Close() })
-		go serveQUIC(args, proxy, listener, quicInitialPacketSize(args.MTU))
+		go serveQUIC(args, proxy, listener, initialPacketSize)
 	}
 
 	infoStr, err := json.Marshal(info)
@@ -433,19 +420,19 @@ func listenKCP(conn net.PacketConn, info *ServerInfo, pass, salt []byte, delegTo
 	return listener, nil
 }
 
-func listenQUIC(conn net.PacketConn, info *ServerInfo, mtu uint16) (*quic.Listener, error) {
+func listenQUIC(conn net.PacketConn, info *ServerInfo, mtu uint16) (*quic.Listener, uint16, error) {
 	serverCertPEM, serverKeyPEM, err := generateCertKeyPair()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	clientCertPEM, clientKeyPEM, err := generateCertKeyPair()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	serverTlsCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
 	if err != nil {
-		return nil, fmt.Errorf("x509 key pair failed: %v", err)
+		return nil, 0, fmt.Errorf("x509 key pair failed: %v", err)
 	}
 
 	clientCertPool := x509.NewCertPool()
@@ -457,12 +444,16 @@ func listenQUIC(conn net.PacketConn, info *ServerInfo, mtu uint16) (*quic.Listen
 	}
 
 	config := quicConfig
-	config.InitialPacketSize = quicInitialPacketSize(mtu)
-	config.DisablePathMTUDiscovery = mtu > 0
+	if mtu > 0 {
+		config.InitialPacketSize = mtu
+		config.DisablePathMTUDiscovery = true
+	} else {
+		config.InitialPacketSize = kDefaultMTU
+	}
 
 	listener, err := (&quic.Transport{Conn: conn}).Listen(tlsConfig, &config)
 	if err != nil {
-		return nil, fmt.Errorf("quic listen failed: %v", err)
+		return nil, 0, fmt.Errorf("quic listen failed: %v", err)
 	}
 
 	info.Mode = kUdpModeQUIC
@@ -470,7 +461,7 @@ func listenQUIC(conn net.PacketConn, info *ServerInfo, mtu uint16) (*quic.Listen
 	info.ClientCert = fmt.Sprintf("%x", clientCertPEM)
 	info.ClientKey = fmt.Sprintf("%x", clientKeyPEM)
 
-	return listener, nil
+	return listener, config.InitialPacketSize, nil
 }
 
 func generateCertKeyPair() ([]byte, []byte, error) {


### PR DESCRIPTION
## Problem

`listenQUIC` and `newQuicClient` mutated the package-level `quicConfig` before starting each listener or dial:

- `InitialPacketSize`
- `DisablePathMTUDiscovery`

That shared mutable config can race when multiple QUIC clients connect concurrently. The race detector reports concurrent reads in quic-go while another goroutine writes the shared config in `newQuicClient`. The same shared mutation can also make independent connections inherit each other's MTU settings.

## Fix

Use the package-level `quicConfig` only as an immutable base:

- copy it into a local `config` for each listener/client;
- set `InitialPacketSize` and `DisablePathMTUDiscovery` on the local copy;
- pass the per-connection initial packet size explicitly to `newQuicDatagramConn` instead of reading it back from shared global state;
- add `quicInitialPacketSize` to centralize default/min/max MTU clamping.

The QUIC MTU test now also checks that the shared base config is not mutated.

## Verification

- `go test ./tsshd -run 'TestQUIC_InitialPacketSize|TestProxy/QUIC_Attachable'`
- `go test -race ./tsshd -run 'TestProxy/QUIC_Attachable'`
- `go test ./...`
- `go vet ./...`
