### PR TITLE
fix: reject empty subsystem commands

### DIFF
--- a/tsshd/session.go
+++ b/tsshd/session.go
@@ -1040,6 +1040,9 @@ func getSubsystemCmd(name string) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, fmt.Errorf("split subsystem [%s] [%s] failed: %v", name, command, err)
 	}
+	if len(args) == 0 || args[0] == "" {
+		return nil, fmt.Errorf("subsystem [%s] command is empty in [%s]", name, sshdConfigPath)
+	}
 	return exec.Command(args[0], args[1:]...), nil
 }
 

--- a/tsshd/session_test.go
+++ b/tsshd/session_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -53,7 +54,7 @@ func TestGetSubsystemCmdEmptyCommand(t *testing.T) {
 		sshdSubsystemMap = origMap
 	}()
 
-	sshdConfigPath = "/tmp/test_sshd_config"
+	sshdConfigPath = filepath.Join(t.TempDir(), "sshd_config")
 	sshdSubsystemMap = map[string]string{"sftp": `""`}
 
 	cmd, err := getSubsystemCmd("sftp")

--- a/tsshd/session_test.go
+++ b/tsshd/session_test.go
@@ -45,6 +45,23 @@ type mockStream struct {
 	first bool
 }
 
+func TestGetSubsystemCmdEmptyCommand(t *testing.T) {
+	origPath := sshdConfigPath
+	origMap := sshdSubsystemMap
+	defer func() {
+		sshdConfigPath = origPath
+		sshdSubsystemMap = origMap
+	}()
+
+	sshdConfigPath = "/tmp/test_sshd_config"
+	sshdSubsystemMap = map[string]string{"sftp": `""`}
+
+	cmd, err := getSubsystemCmd("sftp")
+	require.Error(t, err)
+	require.Nil(t, cmd)
+	require.Contains(t, err.Error(), "command is empty")
+}
+
 func newMockStream() *mockStream {
 	return &mockStream{first: true}
 }


### PR DESCRIPTION
## Problem

`getSubsystemCmd` checked whether a subsystem was configured and whether command-line splitting succeeded, but it did not validate that the resulting argv contained a non-empty executable name.

A malformed subsystem entry such as an empty quoted command can produce an empty argv[0], leading to an unclear failure path when constructing or starting the command.

## Fix

After splitting the subsystem command, explicitly reject empty argv results and empty executable names with a clear error message:

```go
if len(args) == 0 || args[0] == "" { ... }
```

A regression test covers an empty quoted subsystem command.

## Verification

- `go test ./tsshd -run TestGetSubsystemCmdEmptyCommand`
- `go test ./...`
- `go vet ./...`
