### PR TITLE
fix: close parked accept connections the client never claims

### DIFF
--- a/tsshd/forward.go
+++ b/tsshd/forward.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // streamLocalBindMask returns the StreamLocalBindMask from sshd_config.
@@ -195,6 +196,7 @@ func (s *sshUdpServer) handleListenEvent(stream Stream) {
 			break
 		}
 		id := s.addAcceptConn(conn)
+		s.reapAcceptConnAfterTimeout(id)
 		if err := sendMessage(stream, acceptMessage{id}); err != nil {
 			if conn := s.takeAcceptConn(id); conn != nil {
 				_ = conn.Close()
@@ -255,6 +257,28 @@ func (s *sshUdpServer) takeAcceptConn(id uint64) net.Conn {
 	}
 
 	return nil
+}
+
+// reapAcceptConnAfterTimeout closes a parked accept connection if the client
+// does not claim it within ConnectTimeout. Both agent/X11 forwarding (see
+// handleChannelAccept) and -R remote forwarding park the accepted connection
+// in fwdAcceptMap and rely on the client to open the matching channel. When the
+// client side is gone or unresponsive (for example, agent forwarding whose
+// upstream agent has disconnected), the connection would otherwise stay parked
+// forever, leaving callers such as `ssh-add` or `git` SSH commit signing
+// hanging indefinitely. The ConnectTimeout bound mirrors the one the client is
+// expected to connect within (see the run loop in main.go).
+func (s *sshUdpServer) reapAcceptConnAfterTimeout(id uint64) {
+	timeout := kDefaultConnectTimeout
+	if s.args != nil && s.args.ConnectTimeout > 0 {
+		timeout = s.args.ConnectTimeout
+	}
+	time.AfterFunc(timeout, func() {
+		if conn := s.takeAcceptConn(id); conn != nil {
+			warning("accept conn [%d] not claimed within %v, closing", id, timeout)
+			_ = conn.Close()
+		}
+	})
 }
 
 func (s *sshUdpServer) forwardConnection(stream Stream, conn net.Conn) {

--- a/tsshd/forward_test.go
+++ b/tsshd/forward_test.go
@@ -1,0 +1,92 @@
+/*
+MIT License
+
+Copyright (c) 2024-2026 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tsshd
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// closeTrackingConn records whether Close was called, without needing a real
+// network connection. The embedded nil net.Conn is never exercised because the
+// reaper only ever calls Close.
+type closeTrackingConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// TestReapAcceptConnUnclaimed verifies the core fix: an accept connection the
+// client never claims must be closed once ConnectTimeout elapses. Without this,
+// a dead or unresponsive client (e.g. agent forwarding whose upstream agent has
+// gone away) leaves the connection parked forever, which surfaces to the user
+// as `ssh-add` or `git` SSH signing hanging indefinitely.
+func TestReapAcceptConnUnclaimed(t *testing.T) {
+	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
+
+	conn := &closeTrackingConn{}
+	id := server.addAcceptConn(conn)
+	server.reapAcceptConnAfterTimeout(id)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !conn.closed.Load() && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if !conn.closed.Load() {
+		t.Fatal("unclaimed accept conn was not closed after ConnectTimeout")
+	}
+	if c := server.takeAcceptConn(id); c != nil {
+		t.Fatal("reaped accept conn should no longer be parked")
+	}
+}
+
+// TestReapAcceptConnClaimed verifies the reaper never disturbs a connection the
+// client claimed in time: closing a live forwarded connection out from under an
+// in-flight request would itself be a regression.
+func TestReapAcceptConnClaimed(t *testing.T) {
+	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
+
+	conn := &closeTrackingConn{}
+	id := server.addAcceptConn(conn)
+	server.reapAcceptConnAfterTimeout(id)
+
+	if c := server.takeAcceptConn(id); c != conn {
+		t.Fatalf("claim failed, expected ptr %p, got %v", conn, c)
+	}
+
+	// Wait well past ConnectTimeout so the reaper has certainly fired.
+	time.Sleep(100 * time.Millisecond)
+
+	if conn.closed.Load() {
+		t.Fatal("reaper closed an accept conn that was already claimed by the client")
+	}
+}

--- a/tsshd/server_test.go
+++ b/tsshd/server_test.go
@@ -27,7 +27,9 @@ package tsshd
 import (
 	"net"
 	dbg "runtime/debug"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestServerLazyMap(t *testing.T) {
@@ -76,5 +78,65 @@ func TestServerLazyMap(t *testing.T) {
 	server.releaseUdpForwardSession(sess)
 	if size := len(server.udpFwdSessionMap); size != 0 {
 		t.Fatalf("expected session map size 0 after release, got %d", size)
+	}
+}
+
+// closeTrackingConn records whether Close was called, without needing a real
+// network connection. The embedded nil net.Conn is never exercised because the
+// reaper only ever calls Close.
+type closeTrackingConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// TestReapAcceptConnUnclaimed verifies the core fix: an accept connection the
+// client never claims must be closed once ConnectTimeout elapses. Without this,
+// a dead or unresponsive client (e.g. agent forwarding whose upstream agent has
+// gone away) leaves the connection parked forever, which surfaces to the user
+// as `ssh-add` or `git` SSH signing hanging indefinitely.
+func TestReapAcceptConnUnclaimed(t *testing.T) {
+	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
+
+	conn := &closeTrackingConn{}
+	id := server.addAcceptConn(conn)
+	server.reapAcceptConnAfterTimeout(id)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !conn.closed.Load() && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if !conn.closed.Load() {
+		t.Fatal("unclaimed accept conn was not closed after ConnectTimeout")
+	}
+	if c := server.takeAcceptConn(id); c != nil {
+		t.Fatal("reaped accept conn should no longer be parked")
+	}
+}
+
+// TestReapAcceptConnClaimed verifies the reaper never disturbs a connection the
+// client claimed in time: closing a live forwarded connection out from under an
+// in-flight request would itself be a regression.
+func TestReapAcceptConnClaimed(t *testing.T) {
+	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
+
+	conn := &closeTrackingConn{}
+	id := server.addAcceptConn(conn)
+	server.reapAcceptConnAfterTimeout(id)
+
+	if c := server.takeAcceptConn(id); c != conn {
+		t.Fatalf("claim failed, expected ptr %p, got %v", conn, c)
+	}
+
+	// Wait well past ConnectTimeout so the reaper has certainly fired.
+	time.Sleep(100 * time.Millisecond)
+
+	if conn.closed.Load() {
+		t.Fatal("reaper closed an accept conn that was already claimed by the client")
 	}
 }

--- a/tsshd/server_test.go
+++ b/tsshd/server_test.go
@@ -27,9 +27,7 @@ package tsshd
 import (
 	"net"
 	dbg "runtime/debug"
-	"sync/atomic"
 	"testing"
-	"time"
 )
 
 func TestServerLazyMap(t *testing.T) {
@@ -78,65 +76,5 @@ func TestServerLazyMap(t *testing.T) {
 	server.releaseUdpForwardSession(sess)
 	if size := len(server.udpFwdSessionMap); size != 0 {
 		t.Fatalf("expected session map size 0 after release, got %d", size)
-	}
-}
-
-// closeTrackingConn records whether Close was called, without needing a real
-// network connection. The embedded nil net.Conn is never exercised because the
-// reaper only ever calls Close.
-type closeTrackingConn struct {
-	net.Conn
-	closed atomic.Bool
-}
-
-func (c *closeTrackingConn) Close() error {
-	c.closed.Store(true)
-	return nil
-}
-
-// TestReapAcceptConnUnclaimed verifies the core fix: an accept connection the
-// client never claims must be closed once ConnectTimeout elapses. Without this,
-// a dead or unresponsive client (e.g. agent forwarding whose upstream agent has
-// gone away) leaves the connection parked forever, which surfaces to the user
-// as `ssh-add` or `git` SSH signing hanging indefinitely.
-func TestReapAcceptConnUnclaimed(t *testing.T) {
-	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
-
-	conn := &closeTrackingConn{}
-	id := server.addAcceptConn(conn)
-	server.reapAcceptConnAfterTimeout(id)
-
-	deadline := time.Now().Add(2 * time.Second)
-	for !conn.closed.Load() && time.Now().Before(deadline) {
-		time.Sleep(2 * time.Millisecond)
-	}
-
-	if !conn.closed.Load() {
-		t.Fatal("unclaimed accept conn was not closed after ConnectTimeout")
-	}
-	if c := server.takeAcceptConn(id); c != nil {
-		t.Fatal("reaped accept conn should no longer be parked")
-	}
-}
-
-// TestReapAcceptConnClaimed verifies the reaper never disturbs a connection the
-// client claimed in time: closing a live forwarded connection out from under an
-// in-flight request would itself be a regression.
-func TestReapAcceptConnClaimed(t *testing.T) {
-	server := &sshUdpServer{args: &tsshdArgs{ConnectTimeout: 20 * time.Millisecond}}
-
-	conn := &closeTrackingConn{}
-	id := server.addAcceptConn(conn)
-	server.reapAcceptConnAfterTimeout(id)
-
-	if c := server.takeAcceptConn(id); c != conn {
-		t.Fatalf("claim failed, expected ptr %p, got %v", conn, c)
-	}
-
-	// Wait well past ConnectTimeout so the reaper has certainly fired.
-	time.Sleep(100 * time.Millisecond)
-
-	if conn.closed.Load() {
-		t.Fatal("reaper closed an accept conn that was already claimed by the client")
 	}
 }

--- a/tsshd/session.go
+++ b/tsshd/session.go
@@ -1320,6 +1320,7 @@ func (c *sessionContext) handleChannelAccept(listener net.Listener, channelType 
 				return
 			}
 			id := server.addAcceptConn(conn)
+			server.reapAcceptConnAfterTimeout(id)
 			if err := server.sendBusMessage("channel", &channelMessage{ChannelType: channelType, ID: id}); err != nil {
 				warning("send channel message failed: %v", err)
 			}


### PR DESCRIPTION
## Problem

Agent forwarding (and `-R` remote forwarding) can hang a client command forever.

When the daemon accepts a connection on a forwarded socket — e.g. the agent socket it exposes via `SSH_AUTH_SOCK` — it parks the connection in `fwdAcceptMap` and asks the client to open the matching channel. If the client never claims it, the parked connection is never read, written, or closed, so the local caller blocks indefinitely.

This is easy to hit in practice. If the client's forwarded `ssh-agent` has gone away (the upstream agent disconnected, the forwarding channel died, etc.), the agent socket on the server still exists and still accepts connections, but nothing ever services them. Any process that touches it hangs — most visibly `ssh-add -l`, and `git` commit signing with `gpg.format=ssh` (`ssh-keygen -Y sign` queries the agent before falling back to the key file), which makes `git commit` appear to freeze with no output.

## Fix

Reap a parked accept connection after `ConnectTimeout` if it is still unclaimed, closing it so the local caller fails fast instead of hanging. The bound mirrors the one the client is already expected to connect within (see the liveness loop in `main.go`).

`reapAcceptConnAfterTimeout` is armed at both park sites — `handleChannelAccept` (agent / X11) and the `-R` listener accept loop. It is a no-op when the client claims the connection in time: `takeAcceptConn` hands the conn to exactly one caller under `fwdAcceptMutex`, so the reaper and a legitimate claim can never both act on it (no double-close, no use-after-free).

## Tests

- `TestReapAcceptConnUnclaimed` — an unclaimed conn is closed once `ConnectTimeout` elapses.
- `TestReapAcceptConnClaimed` — a conn claimed in time is never touched by the reaper.

`make test` passes locally (`CGO_ENABLED=0 go test -count=1 ./tsshd`).

---
Pix (Claude Opus 4.7 reviewed by GPT 5.5)
