### PR TITLE
ci: add automatic pre-release deployment

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -34,21 +34,6 @@ jobs:
           go-version: "1.25"
       - name: make test
         run: make test
-  go-release-snapshot:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout tsshd
-        uses: actions/checkout@v6
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: "~> v1"
-          args: release --clean --snapshot --skip=publish
   test-win7-patch:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,41 @@
+name: Auto Deploy Dev Build
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  build-pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tsshd
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v1"
+          args: release --clean --snapshot --skip=publish
+      - name: Show Checksum
+        run: |
+          sha256sum dist/*.tar.gz dist/*.zip dist/*.rpm dist/*.deb dist/*_checksums.txt
+      - name: Update Dev Release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "dev"
+          prerelease: true
+          title: "Development Build (main branch)"
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.rpm
+            dist/*.deb
+            dist/*_checksums.txt

--- a/README.cn.md
+++ b/README.cn.md
@@ -206,7 +206,7 @@ tssh 和 tsshd 的工作方式与 ssh 完全相同，没有计划支持本地回
 
   </details>
 
-- 可从 [GitHub Releases](https://github.com/trzsz/tsshd/releases) 中下载，国内可从 [Gitee 发行版](https://gitee.com/trzsz/tsshd/releases) 中下载，然后本地安装。
+- 可从 [GitHub Releases](https://github.com/trzsz/tsshd/releases) 或 [Pre-Release](https://github.com/trzsz/tsshd/releases/tag/dev) 中下载，国内可从 [Gitee 发行版](https://gitee.com/trzsz/tsshd/releases) 中下载，然后本地安装。
 
   <details><summary><code>下载并本地安装</code></summary>
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ tssh and tsshd works exactly like ssh, there are no plans to support local echo 
 
   </details>
 
-- Download from the [GitHub Releases](https://github.com/trzsz/tsshd/releases) and install locally
+- Download from the [GitHub Releases](https://github.com/trzsz/tsshd/releases) (or [Pre-Release](https://github.com/trzsz/tsshd/releases/tag/dev)) and install locally
 
   <details><summary><code>download and install locally</code></summary>
 


### PR DESCRIPTION
### Description
This PR introduces an automated pre-release deployment workflow and updates the documentation accordingly.

### Changes
* **CI**: Added a new GitHub Workflow (`pre-release.yml`) to automatically build and deploy rolling "dev" releases on every push to `main` using GoReleaser.
* **CI**: Removed the redundant `go-release-snapshot` job from `gotest.yml`.
* **Docs**: Updated both English and Chinese `README` files to include the download link for the new "dev" pre-releases.