### PR TITLE
fix: resolve sessionContext memory leak in attachable daemon

### DIFF
--- a/tsshd/attach.go
+++ b/tsshd/attach.go
@@ -268,11 +268,12 @@ func (s *replaceableStream) RemoteAddr() net.Addr {
 }
 
 type replaceableTimeoutChecker struct {
-	mu        sync.Mutex
-	cancel    chan struct{}
-	checker   *timeoutChecker
-	gen       uint64
-	callbacks []func()
+	mu            sync.Mutex
+	cancel        chan struct{}
+	checker       *timeoutChecker
+	gen           uint64
+	callbacks     []func()
+	parentCancels []func()
 }
 
 func newReplaceableTimeoutChecker(checker *timeoutChecker) *replaceableTimeoutChecker {
@@ -287,8 +288,16 @@ func (c *replaceableTimeoutChecker) swap(newChecker *timeoutChecker) {
 	c.cancel = make(chan struct{})
 
 	oldChecker := c.checker
-	c.checker = newChecker
+	if oldChecker != nil {
+		for i, cancel := range c.parentCancels {
+			if cancel != nil {
+				cancel()
+				c.parentCancels[i] = nil
+			}
+		}
+	}
 
+	c.checker = newChecker
 	c.gen++
 
 	if newChecker == nil {
@@ -297,13 +306,30 @@ func (c *replaceableTimeoutChecker) swap(newChecker *timeoutChecker) {
 
 	if oldChecker == nil && !newChecker.isTimeout() {
 		for _, cb := range c.callbacks {
-			go cb()
+			if cb != nil {
+				go cb()
+			}
 		}
 	}
 
-	for _, cb := range c.callbacks {
-		newChecker.onReconnected(c.wrapCallback(cb, c.gen))
+	for i, cb := range c.callbacks {
+		if cb != nil {
+			c.parentCancels[i] = newChecker.onReconnected(c.wrapCallback(cb, c.gen))
+		}
 	}
+}
+
+func (c *replaceableTimeoutChecker) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, cancel := range c.parentCancels {
+		if cancel != nil {
+			cancel()
+			c.parentCancels[i] = nil
+		}
+	}
+	c.callbacks = nil
+	c.parentCancels = nil
 }
 
 func (c *replaceableTimeoutChecker) isTimeout() bool {
@@ -353,15 +379,46 @@ func (c *replaceableTimeoutChecker) waitUntilReconnected() error {
 	}
 }
 
-func (c *replaceableTimeoutChecker) onReconnected(cb func()) {
+func (c *replaceableTimeoutChecker) onReconnected(cb func()) func() {
 	c.mu.Lock()
 	checker, gen := c.checker, c.gen
-	c.callbacks = append(c.callbacks, cb)
-	c.mu.Unlock()
 
+	var myIdx int = -1
+	for i, existing := range c.callbacks {
+		if existing == nil {
+			myIdx = i
+			c.callbacks[i] = cb
+			break
+		}
+	}
+	if myIdx == -1 {
+		myIdx = len(c.callbacks)
+		c.callbacks = append(c.callbacks, cb)
+		c.parentCancels = append(c.parentCancels, nil)
+	}
+
+	var cancelParent func()
 	if checker != nil {
 		wrapper := c.wrapCallback(cb, gen)
-		checker.onReconnected(wrapper)
+		cancelParent = checker.onReconnected(wrapper)
+		c.parentCancels[myIdx] = cancelParent
+	}
+	c.mu.Unlock()
+
+	return func() {
+		c.mu.Lock()
+		if c.callbacks != nil {
+			c.callbacks[myIdx] = nil
+		}
+		var cancelP func()
+		if c.parentCancels != nil {
+			cancelP = c.parentCancels[myIdx]
+			c.parentCancels[myIdx] = nil
+		}
+		c.mu.Unlock()
+		if cancelP != nil {
+			cancelP()
+		}
 	}
 }
 

--- a/tsshd/comm.go
+++ b/tsshd/comm.go
@@ -352,23 +352,57 @@ func (tc *timeoutChecker) updateTime(msec int64) {
 	}
 }
 
-func (tc *timeoutChecker) onTimeout(cb func()) {
+func (tc *timeoutChecker) onTimeout(cb func()) func() {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	for i, existing := range tc.timeoutCallbacks {
+		if existing == nil {
+			tc.timeoutCallbacks[i] = cb
+			return func() {
+				tc.mutex.Lock()
+				tc.timeoutCallbacks[i] = nil
+				tc.mutex.Unlock()
+			}
+		}
+	}
+	i := len(tc.timeoutCallbacks)
 	tc.timeoutCallbacks = append(tc.timeoutCallbacks, cb)
+	return func() {
+		tc.mutex.Lock()
+		tc.timeoutCallbacks[i] = nil
+		tc.mutex.Unlock()
+	}
 }
 
-func (tc *timeoutChecker) onReconnected(cb func()) {
+func (tc *timeoutChecker) onReconnected(cb func()) func() {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	for i, existing := range tc.reconnectedCallbacks {
+		if existing == nil {
+			tc.reconnectedCallbacks[i] = cb
+			return func() {
+				tc.mutex.Lock()
+				tc.reconnectedCallbacks[i] = nil
+				tc.mutex.Unlock()
+			}
+		}
+	}
+	i := len(tc.reconnectedCallbacks)
 	tc.reconnectedCallbacks = append(tc.reconnectedCallbacks, cb)
+	return func() {
+		tc.mutex.Lock()
+		tc.reconnectedCallbacks[i] = nil
+		tc.mutex.Unlock()
+	}
 }
 
 func (tc *timeoutChecker) notifyTimeout() {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 	for _, cb := range tc.timeoutCallbacks {
-		go cb()
+		if cb != nil {
+			go cb()
+		}
 	}
 }
 
@@ -376,7 +410,9 @@ func (tc *timeoutChecker) notifyReconnected() {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 	for _, cb := range tc.reconnectedCallbacks {
-		go cb()
+		if cb != nil {
+			go cb()
+		}
 	}
 }
 

--- a/tsshd/session.go
+++ b/tsshd/session.go
@@ -388,6 +388,8 @@ func (c *sessionContext) Close() {
 	delete(sessionMap, c.id)
 	sessionMutex.Unlock()
 
+	c.clientChecker.Close()
+
 	code := -1
 	if c.mwSess != nil {
 		if exitCode := c.mwSess.exitCode.Load(); exitCode != nil {
@@ -418,6 +420,13 @@ func (c *sessionContext) Close() {
 			_ = c.cmd.Process.Kill()
 			debug("session [%d] cmd killed", c.id)
 		}
+	}
+
+	if c.ioStream != nil {
+		_ = c.ioStream.Close()
+	}
+	if c.errStream != nil {
+		_ = c.errStream.Close()
 	}
 }
 


### PR DESCRIPTION
Resolves #40

### Background
When running `tsshd --attachable`, it starts a background server that stays alive persistently. This server holds a global "checker" object called `server.clientChecker` to detect if the client connection has dropped and trigger reconnections. Every time a new session connects, its `sessionContext` registers a "reconnect callback" so it can resume I/O forwarding if the network drops. 

### The Memory Leak
The `timeoutChecker` was appending these callbacks to an unbounded slice (`reconnectedCallbacks`), but had **no mechanism to remove them**. When a session naturally finished, its callback function remained in the global slice. 

Because the callback is a closure that captures `serverOutputForwarder` (and by extension, the entire `sessionContext` struct), the Go Garbage Collector was completely unable to free any session structs, pipes, or buffers. Every single session ever spawned permanently leaked into memory.

### The Fix
1. Changed `onReconnected` and `onTimeout` to return a cancellation `func()` that zeroes the callback in the slice (with nil-safety checks).
2. Updated `replaceableTimeoutChecker` to maintain an array mapping its own callbacks to the cancellation functions returned by the parent.
3. Added a `Close()` method to `replaceableTimeoutChecker` that triggers these cancellations, severing the link to the parent, and cleaning up arrays.
4. Updated `sessionContext.Close()` to call `c.clientChecker.Close()`.

With these changes, when a session ends, its closure is completely deregistered from the global `server.clientChecker`, allowing the Garbage Collector to properly sweep the session memory.