### PR TITLE
feat: merge datagram-only mode and telemetry enhancements from kitknox/tsshd-rootshell

### DIFF
--- a/tsshd/client.go
+++ b/tsshd/client.go
@@ -519,6 +519,20 @@ func (c *SshUdpClient) GetLastActiveTime() int64 {
 	return c.activeChecker.getAliveTime()
 }
 
+// OnHealthEvent registers callbacks fired when the heartbeat checker
+// transitions into the timeout state (no alive ack within the heartbeat
+// timeout) or recovers from it. Callbacks run on dedicated goroutines and
+// may block briefly. Registration is append-only; register each listener
+// at most once per client.
+func (c *SshUdpClient) OnHealthEvent(onTimeout, onReconnected func()) {
+	if onTimeout != nil {
+		c.activeChecker.onTimeout(onTimeout)
+	}
+	if onReconnected != nil {
+		c.activeChecker.onReconnected(onReconnected)
+	}
+}
+
 // GetLastReconnectError returns the last error encountered during reconnection attempts
 func (c *SshUdpClient) GetLastReconnectError() error {
 	client := c

--- a/tsshd/client.go
+++ b/tsshd/client.go
@@ -385,6 +385,19 @@ func (c *SshUdpClient) DialTimeout(network, addr string, timeout time.Duration) 
 
 // DialUDP initiates a logical UDP connection to the addr from the remote host
 func (c *SshUdpClient) DialUDP(network, addr string, timeout time.Duration) (PacketConn, error) {
+	return c.dialUDP(network, addr, timeout, false)
+}
+
+// DialUDPDatagramOnly is DialUDP with real-UDP send semantics: packets that
+// don't fit the transport's datagram budget (or arrive while the transport is
+// reconnecting) are dropped instead of being delivered over the reliable
+// stream fallback. Intended for tunneling protocols that run their own path
+// MTU discovery, e.g. QUIC.
+func (c *SshUdpClient) DialUDPDatagramOnly(network, addr string, timeout time.Duration) (PacketConn, error) {
+	return c.dialUDP(network, addr, timeout, true)
+}
+
+func (c *SshUdpClient) dialUDP(network, addr string, timeout time.Duration, datagramOnly bool) (PacketConn, error) {
 	stream, err := c.newStream("dial-udp")
 	if err != nil {
 		return nil, err
@@ -406,6 +419,7 @@ func (c *SshUdpClient) DialUDP(network, addr string, timeout time.Duration) (Pac
 	}
 
 	conn := newPacketConn(stream, resp.ID, c.protoClient.getUdpForwarder(), c.clientProxy.serverChecker)
+	conn.datagramOnly = datagramOnly
 
 	var ok udpReadyMessage
 	if err := sendMessage(stream, &ok); err != nil {

--- a/tsshd/datagram.go
+++ b/tsshd/datagram.go
@@ -218,17 +218,18 @@ func (f *udpForwarder) Close() {
 // packetConn implements PacketConn over either QUIC datagrams (unordered)
 // or a reliable stream fallback. Read and Consume are mutually exclusive.
 type packetConn struct {
-	stream     Stream
-	forwarder  *udpForwarder
-	peerCheck  *timeoutChecker
-	readMutex  sync.Mutex
-	readerOnce sync.Once
-	channelID  uint64
-	channelCh  chan []byte
-	streamCh   chan []byte
-	consumeFn  atomic.Pointer[func([]byte) error]
-	closed     atomic.Bool
-	closeCh    chan struct{}
+	stream       Stream
+	forwarder    *udpForwarder
+	peerCheck    *timeoutChecker
+	readMutex    sync.Mutex
+	readerOnce   sync.Once
+	channelID    uint64
+	channelCh    chan []byte
+	streamCh     chan []byte
+	consumeFn    atomic.Pointer[func([]byte) error]
+	closed       atomic.Bool
+	closeCh      chan struct{}
+	datagramOnly bool
 }
 
 func newPacketConn(stream Stream, id uint64, forwarder *udpForwarder, peerCheck *timeoutChecker) *packetConn {
@@ -335,6 +336,21 @@ func (c *packetConn) startStreamReader() {
 }
 
 func (c *packetConn) Write(buf []byte) error {
+	if c.datagramOnly {
+		// Real-UDP semantics: drop instead of blocking on reconnection or
+		// falling back to the reliable stream, so the inner protocol's path
+		// MTU discovery observes genuine losses and converges below the
+		// datagram budget. Only a closed forwarder is a hard error.
+		if c.forwarder == nil || c.forwarder.closed.Load() {
+			return io.ErrClosedPipe
+		}
+		if c.peerCheck.isTimeout() {
+			return nil
+		}
+		_ = c.forwarder.sendDatagram(c.channelID, buf)
+		return nil
+	}
+
 	if c.peerCheck.isTimeout() {
 		if err := c.peerCheck.waitUntilReconnected(); err != nil {
 			return err

--- a/tsshd/datagram_test.go
+++ b/tsshd/datagram_test.go
@@ -1,0 +1,176 @@
+/*
+MIT License
+
+Copyright (c) 2026 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tsshd
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeDatagramConn records SendDatagram calls and enforces a fixed budget.
+type fakeDatagramConn struct {
+	mu      sync.Mutex
+	maxSize uint16
+	sent    [][]byte
+	recvCh  chan []byte
+}
+
+func newFakeDatagramConn(maxSize uint16) *fakeDatagramConn {
+	return &fakeDatagramConn{maxSize: maxSize, recvCh: make(chan []byte, 16)}
+}
+
+func (c *fakeDatagramConn) GetMaxDatagramSize() uint16 {
+	return c.maxSize
+}
+
+func (c *fakeDatagramConn) SendDatagram(data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sent = append(c.sent, append([]byte(nil), data...))
+	return nil
+}
+
+func (c *fakeDatagramConn) ReceiveDatagram(ctx context.Context) ([]byte, error) {
+	select {
+	case buf := <-c.recvCh:
+		return buf, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *fakeDatagramConn) sentCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.sent)
+}
+
+// fakeStream is an in-memory Stream that records writes (the reliable
+// stream fallback path).
+type fakeStream struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *fakeStream) Read(p []byte) (int, error) {
+	select {} // tests never read; block forever like an idle stream
+}
+
+func (s *fakeStream) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *fakeStream) Close() error                       { return nil }
+func (s *fakeStream) CloseRead() error                   { return nil }
+func (s *fakeStream) CloseWrite() error                  { return nil }
+func (s *fakeStream) LocalAddr() net.Addr                { return nil }
+func (s *fakeStream) RemoteAddr() net.Addr               { return nil }
+func (s *fakeStream) SetDeadline(t time.Time) error      { return nil }
+func (s *fakeStream) SetReadDeadline(t time.Time) error  { return nil }
+func (s *fakeStream) SetWriteDeadline(t time.Time) error { return nil }
+
+func (s *fakeStream) written() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Len()
+}
+
+func newTestPacketConn(t *testing.T, budget uint16, datagramOnly bool) (*packetConn, *fakeDatagramConn, *fakeStream) {
+	t.Helper()
+	dc := newFakeDatagramConn(budget)
+	forwarder := &udpForwarder{conn: dc}
+	stream := &fakeStream{}
+	checker := newTimeoutChecker(0)
+	t.Cleanup(checker.Close)
+	conn := newPacketConn(stream, 1, forwarder, checker)
+	conn.datagramOnly = datagramOnly
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, dc, stream
+}
+
+func TestPacketConn_DatagramOnlyDropsOversize(t *testing.T) {
+	conn, dc, stream := newTestPacketConn(t, 100, true)
+
+	// Fits the budget (payload + 8-byte channel tag): sent as a datagram.
+	if err := conn.Write(make([]byte, 92)); err != nil {
+		t.Fatalf("in-budget write failed: %v", err)
+	}
+	if dc.sentCount() != 1 {
+		t.Fatalf("expected 1 datagram sent, got %d", dc.sentCount())
+	}
+
+	// Oversize: dropped silently, never the reliable stream.
+	if err := conn.Write(make([]byte, 500)); err != nil {
+		t.Fatalf("oversize write should drop, got error: %v", err)
+	}
+	if dc.sentCount() != 1 {
+		t.Fatalf("oversize payload must not be sent as a datagram")
+	}
+	if stream.written() != 0 {
+		t.Fatalf("oversize payload must not fall back to the stream, wrote %d bytes", stream.written())
+	}
+}
+
+func TestPacketConn_DefaultKeepsStreamFallback(t *testing.T) {
+	conn, dc, stream := newTestPacketConn(t, 100, false)
+
+	if err := conn.Write(make([]byte, 500)); err != nil {
+		t.Fatalf("fallback write failed: %v", err)
+	}
+	if dc.sentCount() != 0 {
+		t.Fatalf("oversize payload must not be sent as a datagram")
+	}
+	if stream.written() == 0 {
+		t.Fatalf("oversize payload should have fallen back to the stream")
+	}
+}
+
+func TestPacketConn_DatagramOnlyDropsDuringReconnect(t *testing.T) {
+	conn, dc, stream := newTestPacketConn(t, 100, true)
+	conn.peerCheck.timeoutFlag.Store(true)
+
+	// Must neither block waiting for reconnection nor use the stream.
+	if err := conn.Write(make([]byte, 50)); err != nil {
+		t.Fatalf("write during reconnect should drop, got error: %v", err)
+	}
+	if dc.sentCount() != 0 || stream.written() != 0 {
+		t.Fatalf("write during reconnect must be dropped")
+	}
+}
+
+func TestPacketConn_DatagramOnlyClosedForwarder(t *testing.T) {
+	conn, _, _ := newTestPacketConn(t, 100, true)
+	conn.forwarder.Close()
+
+	if err := conn.Write(make([]byte, 50)); err == nil {
+		t.Fatalf("write on closed forwarder should return an error")
+	}
+}

--- a/tsshd/proto.go
+++ b/tsshd/proto.go
@@ -423,6 +423,7 @@ type protocolClient interface {
 	closeClient() error
 	getUdpForwarder() *udpForwarder
 	newStream(connectTimeout time.Duration) (Stream, error)
+	stats(s *TransportStats)
 }
 
 type kcpClient struct {

--- a/tsshd/proxy_client.go
+++ b/tsshd/proxy_client.go
@@ -154,6 +154,16 @@ type clientProxy struct {
 	closed        atomic.Bool
 	udpTraffic    *trafficStats
 	proxyCmds     []string
+	cumTraffic    cumulativeTraffic
+}
+
+// cumulativeTraffic counts UDP wire datagrams for the lifetime of the
+// connection (always on, unlike the windowed debug-only trafficStats).
+type cumulativeTraffic struct {
+	sentPackets atomic.Uint64
+	sentBytes   atomic.Uint64
+	recvPackets atomic.Uint64
+	recvBytes   atomic.Uint64
 }
 
 func (p *clientProxy) clearBackendConn(oldConn *serverConnHolder) {
@@ -447,6 +457,9 @@ func (p *clientProxy) ReadFrom(buf []byte) (int, net.Addr, error) {
 
 			p.serverChecker.updateNow()
 
+			p.cumTraffic.recvPackets.Add(1)
+			p.cumTraffic.recvBytes.Add(uint64(n))
+
 			if p.client.enableDebugging && p.udpTraffic.recFlag.Load() {
 				p.udpTraffic.recvCount.Add(1)
 				p.udpTraffic.recvBytes.Add(uint64(n))
@@ -473,9 +486,13 @@ func (p *clientProxy) WriteTo(buf []byte, _ net.Addr) (int, error) {
 		if err := conn.Write(buf); err != nil {
 			p.client.debug("backend write failed: %v", err)
 			p.clearBackendConn(conn)
-		} else if p.client.enableDebugging && p.udpTraffic.recFlag.Load() {
-			p.udpTraffic.sendCount.Add(1)
-			p.udpTraffic.sendBytes.Add(uint64(len(buf)))
+		} else {
+			p.cumTraffic.sentPackets.Add(1)
+			p.cumTraffic.sentBytes.Add(uint64(len(buf)))
+			if p.client.enableDebugging && p.udpTraffic.recFlag.Load() {
+				p.udpTraffic.sendCount.Add(1)
+				p.udpTraffic.sendBytes.Add(uint64(len(buf)))
+			}
 		}
 	}
 

--- a/tsshd/stats.go
+++ b/tsshd/stats.go
@@ -1,0 +1,112 @@
+/*
+MIT License
+
+Copyright (c) 2024-2026 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tsshd
+
+import (
+	kcp "github.com/trzsz/kcp-go/v5"
+)
+
+// TransportStats is a point-in-time snapshot of transport-level statistics
+// for a client connection. All counters are int64 and durations are in
+// milliseconds so bindings without uint64 support (gomobile) can mirror it.
+type TransportStats struct {
+	Mode string // kUdpModeKCP or kUdpModeQUIC
+
+	// RTT estimates in milliseconds.
+	SRTTMs      int64
+	RTTVarMs    int64
+	MinRTTMs    int64 // QUIC only (HasMinRTT)
+	LatestRTTMs int64 // QUIC only (HasMinRTT)
+	RTOMs       int64 // KCP only (HasRTO)
+
+	// Cumulative transport counters.
+	// QUIC: protocol-level from quic.ConnectionStats (incl. retransmissions).
+	// KCP: UDP wire-level from the client proxy (incl. KCP framing/retrans).
+	BytesSent       int64
+	BytesReceived   int64
+	PacketsSent     int64
+	PacketsReceived int64
+
+	// QUIC-only loss accounting (HasLoss). Not monotonic: packets declared
+	// lost can subsequently arrive.
+	BytesLost   int64
+	PacketsLost int64
+
+	// KCP-only retransmitted segments. PROCESS-GLOBAL across every KCP
+	// session in this process (RetransIsGlobal), from kcp.DefaultSnmp.
+	RetransSegs int64
+
+	HasMinRTT       bool
+	HasRTO          bool
+	HasLoss         bool
+	RetransIsGlobal bool
+}
+
+func (c *kcpClient) stats(s *TransportStats) {
+	s.Mode = kUdpModeKCP
+	s.SRTTMs = int64(c.conn.GetSRTT())
+	s.RTTVarMs = int64(c.conn.GetSRTTVar())
+	s.RTOMs = int64(c.conn.GetRTO())
+	s.HasRTO = true
+	s.RetransSegs = int64(kcp.DefaultSnmp.Copy().RetransSegs)
+	s.RetransIsGlobal = true
+	// Byte/packet counters are filled from the client proxy by the caller.
+}
+
+func (c *quicClient) stats(s *TransportStats) {
+	cs := c.conn.ConnectionStats()
+	s.Mode = kUdpModeQUIC
+	s.SRTTMs = cs.SmoothedRTT.Milliseconds()
+	s.RTTVarMs = cs.MeanDeviation.Milliseconds()
+	s.MinRTTMs = cs.MinRTT.Milliseconds()
+	s.LatestRTTMs = cs.LatestRTT.Milliseconds()
+	s.HasMinRTT = true
+	s.BytesSent = int64(cs.BytesSent)
+	s.BytesReceived = int64(cs.BytesReceived)
+	s.PacketsSent = int64(cs.PacketsSent)
+	s.PacketsReceived = int64(cs.PacketsReceived)
+	s.BytesLost = int64(cs.BytesLost)
+	s.PacketsLost = int64(cs.PacketsLost)
+	s.HasLoss = true
+}
+
+// GetTransportStats returns a snapshot of live transport statistics, or nil
+// if the client is closed or has no transport. Safe from any goroutine:
+// protoClient and clientProxy are write-once before the client is published,
+// and all counters are atomics.
+func (c *SshUdpClient) GetTransportStats() *TransportStats {
+	if c.closed.Load() || c.protoClient == nil {
+		return nil
+	}
+	s := &TransportStats{}
+	c.protoClient.stats(s)
+	if s.Mode == kUdpModeKCP && c.clientProxy != nil {
+		s.BytesSent = int64(c.clientProxy.cumTraffic.sentBytes.Load())
+		s.BytesReceived = int64(c.clientProxy.cumTraffic.recvBytes.Load())
+		s.PacketsSent = int64(c.clientProxy.cumTraffic.sentPackets.Load())
+		s.PacketsReceived = int64(c.clientProxy.cumTraffic.recvPackets.Load())
+	}
+	return s
+}


### PR DESCRIPTION
## Description
This PR integrates the modifications originally developed in the [kitknox/tsshd-rootshell](https://github.com/kitknox/tsshd-rootshell) repository. It introduces three major enhancements to the `tsshd` client to better support modern tunneling protocols (like QUIC), improve application-level state management, and provide deep visibility into network performance. 

## Key Changes

### 1. Strict Datagram-Only Mode (`DialUDPDatagramOnly`)
* **The Problem**: Previously, packets that exceeded the transport's datagram budget or arrived during a reconnection phase would fall back to a reliable stream or block. This breaks Path MTU Discovery (PMTUD) and congestion control for inner protocols like QUIC, which rely on genuine packet loss to converge on optimal transmission sizes.
* **The Solution**: Added `DialUDPDatagramOnly`. When enabled, the connection enforces real-UDP semantics: oversized packets or packets sent during a timeout/reconnect state are silently dropped instead of triggering a stream fallback. 
* Fully covered by new unit tests in `datagram_test.go`.

### 2. Transport Telemetry & Statistics (`GetTransportStats`)
* Introduced a new `TransportStats` struct and `GetTransportStats()` method to provide a point-in-time snapshot of the underlying transport (RTT, bytes/packets sent/received, packet loss).
* Specifically designed using `int64` and milliseconds to ensure full compatibility with bindings that lack `uint64` support (e.g., `gomobile`).
* **KCP & QUIC Support**: 
  * QUIC seamlessly exposes its native `quic.ConnectionStats`.
  * KCP is supported by introducing a new, highly performant `cumulativeTraffic` tracker in `clientProxy` utilizing `atomic.Uint64` to guarantee thread safety without lock contention.

### 3. Connection Health Events (`OnHealthEvent`)
* Added `OnHealthEvent(onTimeout, onReconnected func())` to allow higher-level applications to register callbacks when the heartbeat checker transitions into or recovers from a timeout state.
* This allows UI components or supervisors to react instantly to network blackouts without waiting for hard read/write failures.

## Acknowledgements / References
* Modifications ported and merged from [kitknox/tsshd-rootshell](https://github.com/kitknox/tsshd-rootshell). 
* Special thanks to @kitknox for the original implementation and design!

## Testing
- [x] Added `datagram_test.go` covering oversize dropping, reconnect dropping, default fallback behavior, and forwarder closure.
- [x] Verified `atomic` counters in high-throughput `ReadFrom`/`WriteTo` paths to ensure zero data races.